### PR TITLE
github: Switch test runner to MacOS and add an iOS canary test

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,5 +11,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - uses: actions/cache@v1
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('gradle/dependencies.gradle') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
     - name: Run unit tests and code analyzers
       run: ./gradlew check

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,11 +11,5 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/cache@v1
-      with:
-        path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('gradle/dependencies.gradle') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
     - name: Run unit tests and code analyzers
       run: ./gradlew check

--- a/shared/src/iosTest/kotlin/me/saket/press/shared/CanaryTest.kt
+++ b/shared/src/iosTest/kotlin/me/saket/press/shared/CanaryTest.kt
@@ -1,0 +1,11 @@
+package me.saket.press.shared
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class CanaryTest {
+
+  @Test fun canary() {
+    assertEquals(Platform.name, "iOS")
+  }
+}


### PR DESCRIPTION
Fixes #3 ~(?)~ :rocket: 
Fixes #16 

It seems like it did the job but I don't have a MacOS machine locally to confirm expected output, other than the [warning about iOS targets](https://github.com/saket/Press/runs/342059549#step:3:28) being unsupported not showing up anymore.