### PR TITLE
Updated Reaktive to 1.1.4

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -10,7 +10,7 @@ buildscript {
       squareInject: '0.5.2',
       coroutines: '1.3.2',
       flexmark: '0.50.26',
-      reaktive: '1.1.3',
+      reaktive: '1.1.4',
       koin: '2.1.6-mp',
       flipper: '0.23.5',
       klock: '1.8.0',


### PR DESCRIPTION
A possible crash when using `mainScheduler` on iOS was fixed