### PR TITLE
gitignore: Add .idea/sqldelight/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ captures/
 /local.properties
 /.idea/caches
 /.idea/libraries
+/.idea/sqldelight
 /.idea/modules.xml
 /.idea/workspace.xml
 /.idea/navEditor.xml


### PR DESCRIPTION
SqlDelight's IDE plugin uses this file for linking query functions to .sq files and shouldn't be checked-in as its generated on every gradle sync.