### PR TITLE
Add launcher shortcut for creating new note

### DIFF
--- a/androidApp/src/debug/res/xml/shortcuts.xml
+++ b/androidApp/src/debug/res/xml/shortcuts.xml
@@ -1,0 +1,15 @@
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+  <shortcut
+    android:shortcutId="add_new_note"
+    android:enabled="true"
+    android:icon="@drawable/ic_launcher_shortcut"
+    android:shortcutShortLabel="@string/shortcut_short_label"
+    android:shortcutLongLabel="@string/shortcut_long_label"
+    android:shortcutDisabledMessage="@string/shortcut_disabled">
+    <intent
+      android:action="android.intent.action.VIEW"
+      android:targetPackage="me.saket.press.debug"
+      android:targetClass="press.IntentReceiverActivity" />
+    <categories android:name="android.shortcut.conversation" />
+  </shortcut>
+</shortcuts>

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -20,8 +20,11 @@
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />
       </intent-filter>
+      <meta-data
+        android:name="android.app.shortcuts"
+        android:resource="@xml/shortcuts" />
     </activity>
-
+    <activity android:name="press.IntentReceiverActivity"/>
     <activity
       android:name="press.editor.EditorActivity"
       android:theme="@style/AppTheme.TransparentWindow"

--- a/androidApp/src/main/java/press/IntentReceiverActivity.kt
+++ b/androidApp/src/main/java/press/IntentReceiverActivity.kt
@@ -1,0 +1,20 @@
+package press
+
+import android.app.Activity
+import android.os.Bundle
+import press.editor.EditorActivity
+
+class IntentReceiverActivity : Activity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    processIntent()
+
+  }
+
+  private fun processIntent() {
+
+    val intent = EditorActivity.intent(this)
+    startActivity(intent)
+    finish()
+  }
+}

--- a/androidApp/src/main/java/press/editor/EditorActivity.kt
+++ b/androidApp/src/main/java/press/editor/EditorActivity.kt
@@ -97,7 +97,8 @@ class EditorActivity : ThemeAwareActivity() {
       return Uuid.parse(intent.getStringExtra(KEY_NOTE_ID)!!)!!
     }
 
-    private fun intent(context: Context): Intent {
+    @JvmStatic
+    fun intent(context: Context): Intent {
       return Intent(context, EditorActivity::class.java).apply {
         putExtra(KEY_NOTE_ID, uuid4().toString())
       }

--- a/androidApp/src/main/res/drawable/ic_launcher_shortcut.xml
+++ b/androidApp/src/main/res/drawable/ic_launcher_shortcut.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:autoMirrored="true"
+  android:height="24dp"
+  android:viewportHeight="24.0"
+  android:viewportWidth="24.0"
+  android:width="24dp">
+
+  <path
+    android:fillColor="#676666"
+    android:pathData="M14,2L6,2c-1.1,0 -1.99,0.9 -1.99,2L4,20c0,1.1 0.89,2 1.99,2L18,22c1.1,0 2,-0.9 2,-2L20,8l-6,-6zM16,16h-3v3h-2v-3L8,16v-2h3v-3h2v3h3v2zM13,9L13,3.5L18.5,9L13,9z" />
+</vector>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -1,3 +1,6 @@
 <resources>
     <string name="app_name">Press</string>
+    <string name="shortcut_short_label">Add a new note</string>
+    <string name="shortcut_long_label">Add a new note</string>
+    <string name="shortcut_disabled">This action is not allowed</string>
 </resources>

--- a/androidApp/src/main/res/xml/shortcuts.xml
+++ b/androidApp/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,15 @@
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+  <shortcut
+    android:shortcutId="add_new_note"
+    android:enabled="true"
+    android:icon="@drawable/ic_launcher_shortcut"
+    android:shortcutShortLabel="@string/shortcut_short_label"
+    android:shortcutLongLabel="@string/shortcut_long_label"
+    android:shortcutDisabledMessage="@string/shortcut_disabled">
+    <intent
+      android:action="android.intent.action.VIEW"
+      android:targetPackage="me.saket.press"
+      android:targetClass="press.IntentReceiverActivity" />
+    <categories android:name="android.shortcut.conversation" />
+  </shortcut>
+</shortcuts>


### PR DESCRIPTION
* Added a static shortcut for opening the `EditorActivity` 
*  Removed the unresolved `setText` import from `EditorView`

Fixes #1 