### PR TITLE
Fix failing tests in AutoFormatOnEnterPressTest on native

### DIFF
--- a/wysiwyg/src/commonMain/kotlin/me/saket/wysiwyg/Atomics.kt
+++ b/wysiwyg/src/commonMain/kotlin/me/saket/wysiwyg/Atomics.kt
@@ -1,0 +1,7 @@
+package me.saket.wysiwyg
+
+/**
+ * Common wrapper for atomicLazy() that is only available on native.
+ * https://github.com/Kotlin/kotlinx.atomicfu/issues/135
+ */
+expect fun <T> atomicLazy(initializer: () -> T): Lazy<T>

--- a/wysiwyg/src/commonMain/kotlin/me/saket/wysiwyg/formatting/AutoFormatOnEnterPress.kt
+++ b/wysiwyg/src/commonMain/kotlin/me/saket/wysiwyg/formatting/AutoFormatOnEnterPress.kt
@@ -1,9 +1,9 @@
 package me.saket.wysiwyg.formatting
 
+import me.saket.wysiwyg.atomicLazy
 import me.saket.wysiwyg.formatting.ReplaceNewLineWith.DeleteLetters
 import me.saket.wysiwyg.formatting.ReplaceNewLineWith.InsertLetters
 import me.saket.wysiwyg.util.isDigit
-import kotlin.LazyThreadSafetyMode.NONE
 
 object AutoFormatOnEnterPress {
 
@@ -55,7 +55,7 @@ object AutoFormatOnEnterPress {
   }
 
   private object StartFencedCodeBlock : OnEnterAutoFormatter {
-    val fencedCodeRegex by lazy(NONE) { Regex("(```)[a-z]*[\\s\\S]*?(```)") }
+    val fencedCodeRegex by atomicLazy { Regex("(```)[a-z]*[\\s\\S]*?(```)") }
 
     override fun onEnter(
       text: CharSequence,
@@ -95,7 +95,7 @@ object AutoFormatOnEnterPress {
   }
 
   private object ListContinuation : OnEnterAutoFormatter {
-    private val orderedItemRegex by lazy(NONE) { Regex("(\\d+)\\.\\s") }
+    private val orderedItemRegex by atomicLazy { Regex("(\\d+)\\.\\s") }
 
     @Suppress("NAME_SHADOWING")
     override fun onEnter(

--- a/wysiwyg/src/iosMain/kotlin/me/saket/wysiwyg/Atomics.kt
+++ b/wysiwyg/src/iosMain/kotlin/me/saket/wysiwyg/Atomics.kt
@@ -1,0 +1,3 @@
+package me.saket.wysiwyg
+
+actual fun <T> atomicLazy(initializer: () -> T): Lazy<T> = kotlin.native.concurrent.atomicLazy(initializer)

--- a/wysiwyg/src/macosMain/kotlin/me/saket/wysiwyg/Atomics.kt
+++ b/wysiwyg/src/macosMain/kotlin/me/saket/wysiwyg/Atomics.kt
@@ -1,0 +1,3 @@
+package me.saket.wysiwyg
+
+actual fun <T> atomicLazy(initializer: () -> T): Lazy<T> = kotlin.native.concurrent.atomicLazy(initializer)

--- a/wysiwyg/src/main/kotlin/me/saket/wysiwyg/Atomics.kt
+++ b/wysiwyg/src/main/kotlin/me/saket/wysiwyg/Atomics.kt
@@ -1,0 +1,5 @@
+package me.saket.wysiwyg
+
+import kotlin.LazyThreadSafetyMode.NONE
+
+actual fun <T> atomicLazy(initializer: () -> T): Lazy<T> = lazy(NONE, initializer)


### PR DESCRIPTION
TIL `object` is by default frozen on kotlin native ([more info here](https://dev.to/touchlab/practical-kotlin-native-concurrency-part-2-48ac)).