### PR TITLE
"Superior Testing: Make Fakes not Mocks" is a dead link

### DIFF
--- a/documentation/testing.md
+++ b/documentation/testing.md
@@ -41,4 +41,4 @@ Let’s make this worse. What happens if `Adder#add()` is changed to return a `S
 The test will continue to pass, but the implementation won’t work anymore.  Mocks become worse when we start passing around a “promise” of result instead of the actual result. 
 
 If you’re still unconvinced, Artur Dryomov’s blog post is a good read this subject:
-[Superior Testing: Make Fakes not Mocks](https://arturdryomov.online/posts/superior-testing-make-fakes-not-mocks/)
+[Superior Testing: Make Fakes not Mocks](https://arturdryomov.dev/posts/superior-testing-make-fakes-not-mocks/)


### PR DESCRIPTION
Artur Dryomov’s blog post link attached at the end of testing.md file is a dead one, I've found the correct one and fixed it 