### PR TITLE
Add Delete action

### DIFF
--- a/androidApp/src/main/java/press/editor/EditorView.kt
+++ b/androidApp/src/main/java/press/editor/EditorView.kt
@@ -50,6 +50,7 @@ import me.saket.press.shared.editor.EditorUiEffect.UpdateNoteText
 import me.saket.press.shared.editor.EditorUiModel
 import me.saket.press.shared.editor.ToolbarIconKind.Archive
 import me.saket.press.shared.editor.ToolbarIconKind.CopyAs
+import me.saket.press.shared.editor.ToolbarIconKind.DeleteNote
 import me.saket.press.shared.editor.ToolbarIconKind.DuplicateNote
 import me.saket.press.shared.editor.ToolbarIconKind.OpenInSplitScreen
 import me.saket.press.shared.editor.ToolbarIconKind.ShareAs
@@ -281,6 +282,7 @@ class EditorView @InflationInject constructor(
       CopyAs -> R.drawable.ic_twotone_file_copy_24
       DuplicateNote -> R.drawable.ic_twotone_note_add_24
       OpenInSplitScreen -> R.drawable.ic_twotone_vertical_split_24
+      DeleteNote -> R.drawable.ic_twotone_delete_24
       null -> null
     }
     val icon = iconRes?.let { context.getDrawable(iconRes, palette.accentColor) }

--- a/shared/src/commonMain/kotlin/me/saket/press/shared/editor/EditorPresenter.kt
+++ b/shared/src/commonMain/kotlin/me/saket/press/shared/editor/EditorPresenter.kt
@@ -104,6 +104,7 @@ class EditorPresenter(
           handleArchiveClicks(events, noteStream),
           handleShareClicks(events),
           handleDuplicateNoteClicks(events, noteStream),
+          handleDeleteNoteClicks(events, noteStream),
           handleSplitScreenClicks(events, noteStream),
           handleCopyClicks(events),
           populateExistingNoteOnStart(noteStream),
@@ -359,6 +360,20 @@ class EditorPresenter(
         args.navigator.lfg(
           EditorScreenKey(NewNote(PreSavedNoteId(newNoteId)))
         )
+      }
+  }
+
+  private fun handleDeleteNoteClicks(
+    events: Observable<EditorEvent>,
+    noteStream: Observable<Note>
+  ): Observable<EditorUiModel> {
+
+    return events.ofType<DeleteNoteClicked>()
+      .withLatestFrom(noteStream)
+      .observeOn(schedulers.io)
+      .consumeOnNext { (_, note) ->
+        noteQueries.markAsPendingDeletion(note.id)
+        args.navigator.goBack()
       }
   }
 

--- a/shared/src/commonMain/kotlin/me/saket/press/shared/editor/EditorPresenter.kt
+++ b/shared/src/commonMain/kotlin/me/saket/press/shared/editor/EditorPresenter.kt
@@ -26,6 +26,7 @@ import me.saket.press.data.shared.Note
 import me.saket.press.shared.db.NoteId
 import me.saket.press.shared.editor.EditorEvent.ArchiveToggleClicked
 import me.saket.press.shared.editor.EditorEvent.CopyAsClicked
+import me.saket.press.shared.editor.EditorEvent.DeleteNoteClicked
 import me.saket.press.shared.editor.EditorEvent.DuplicateNoteClicked
 import me.saket.press.shared.editor.EditorEvent.NoteTextChanged
 import me.saket.press.shared.editor.EditorEvent.ShareAsClicked
@@ -40,6 +41,7 @@ import me.saket.press.shared.editor.TextFormat.Markdown
 import me.saket.press.shared.editor.TextFormat.RichText
 import me.saket.press.shared.editor.ToolbarIconKind.Archive
 import me.saket.press.shared.editor.ToolbarIconKind.CopyAs
+import me.saket.press.shared.editor.ToolbarIconKind.DeleteNote
 import me.saket.press.shared.editor.ToolbarIconKind.DuplicateNote
 import me.saket.press.shared.editor.ToolbarIconKind.OpenInSplitScreen
 import me.saket.press.shared.editor.ToolbarIconKind.ShareAs
@@ -261,6 +263,11 @@ class EditorPresenter(
             clickEvent = SplitScreenClicked
           )
         } else null,
+        ToolbarMenuAction(
+          label = strings.editor.menu_delete_note,
+          icon = DeleteNote,
+          clickEvent = DeleteNoteClicked
+        ),
       )
     }
   }

--- a/shared/src/commonMain/kotlin/me/saket/press/shared/editor/EditorUi.kt
+++ b/shared/src/commonMain/kotlin/me/saket/press/shared/editor/EditorUi.kt
@@ -72,5 +72,6 @@ enum class ToolbarIconKind {
   ShareAs,
   CopyAs,
   DuplicateNote,
-  OpenInSplitScreen
+  OpenInSplitScreen,
+  DeleteNote
 }

--- a/shared/src/commonMain/kotlin/me/saket/press/shared/editor/EditorUi.kt
+++ b/shared/src/commonMain/kotlin/me/saket/press/shared/editor/EditorUi.kt
@@ -28,6 +28,7 @@ interface EditorEvent {
   data class CopyAsClicked(val format: TextFormat) : EditorEvent
   object DuplicateNoteClicked : EditorEvent
   object SplitScreenClicked : EditorEvent
+  object DeleteNoteClicked : EditorEvent
 }
 
 data class EditorUiModel(

--- a/shared/src/commonMain/kotlin/me/saket/press/shared/editor/SharedEditorComponent.kt
+++ b/shared/src/commonMain/kotlin/me/saket/press/shared/editor/SharedEditorComponent.kt
@@ -12,6 +12,7 @@ class SharedEditorComponent {
       EditorPresenter(
         args = args,
         database = get(),
+        syncer = get(),
         clock = get(),
         schedulers = get(),
         strings = get(),

--- a/shared/src/commonMain/kotlin/me/saket/press/shared/localization/Strings.kt
+++ b/shared/src/commonMain/kotlin/me/saket/press/shared/localization/Strings.kt
@@ -42,6 +42,7 @@ class Strings(
     val menu_copy_as_richtext: String,
     val menu_duplicate_note: String,
     val menu_open_in_split_screen: String,
+    val menu_delete_note: String,
 
     val note_archived: String,
     val note_unarchived: String,
@@ -143,6 +144,7 @@ val ENGLISH_STRINGS = Strings(
     menu_copy_as_richtext = "Rich Text",
     menu_duplicate_note = "Duplicate note",
     menu_open_in_split_screen = "Split screen",
+    menu_delete_note = "Delete note",
 
     note_archived = "Note archived",
     note_unarchived = "Note unarchived",


### PR DESCRIPTION
This change adds the ability for users to delete notes using a menu action within the toolbar (under "Split screen").

This is done by marking the note as pending for deletion.

`isPendingDeletion` was already available, I just used it for this action. The icon `R.drawable.ic_twotone_delete_24` was also already within the app.

**Screenshot (Click for bigger preview):**
[![Screenshot](https://i.imgur.com/SpEzvKsm.png)](https://i.imgur.com/SpEzvKs.png)