### PR TITLE
use ECDSA key, because GitHub dropped RSA support

### DIFF
--- a/kgit/src/commonMain/kotlin/me/saket/kgit/GitErrorRecoveryResult.kt
+++ b/kgit/src/commonMain/kotlin/me/saket/kgit/GitErrorRecoveryResult.kt
@@ -5,7 +5,10 @@ enum class GitErrorRecoveryResult {
 
   NetworkError,
 
-  /** Likely means that the ssh-key wasn't authorized to access the repository. */
+  /**
+   * Likely means that the ssh-key wasn't authorized to access the repository
+   * or an old RSA key was previously deployed, which isn't supported by GitHub anymore.
+   */
   AuthFailed,
 
   UnknownError,

--- a/kgit/src/commonMain/kotlin/me/saket/kgit/SshKeygen.kt
+++ b/kgit/src/commonMain/kotlin/me/saket/kgit/SshKeygen.kt
@@ -5,7 +5,7 @@ interface SshKeygen {
    * @param comment text to add at the end of the public key for identifying
    * the creator. People usually use their email address here.
    */
-  fun generateRsa(comment: String): SshKeyPair
+  fun generateEcdsa(comment: String): SshKeyPair
 }
 
 expect class RealSshKeygen() : SshKeygen

--- a/kgit/src/jvmMain/kotlin/me/saket/kgit/RealGitRepository.kt
+++ b/kgit/src/jvmMain/kotlin/me/saket/kgit/RealGitRepository.kt
@@ -359,6 +359,9 @@ internal actual class RealGitRepository actual constructor(
       if (e.message?.contains("unknown host", ignoreCase = true) == true) {
         return NetworkError
       }
+      if (e.message?.contains("You're using an RSA key with SHA-1", ignoreCase = true) == true) {
+        return AuthFailed
+      }
       if (e.cause is IOException) {
         return NetworkError
       }

--- a/kgit/src/jvmMain/kotlin/me/saket/kgit/RealSshKeygen.kt
+++ b/kgit/src/jvmMain/kotlin/me/saket/kgit/RealSshKeygen.kt
@@ -5,8 +5,8 @@ import com.jcraft.jsch.KeyPair
 import java.io.ByteArrayOutputStream
 
 actual class RealSshKeygen : SshKeygen {
-  override fun generateRsa(comment: String): SshKeyPair {
-    val keyPair: KeyPair = KeyPair.genKeyPair(JSch(), KeyPair.RSA)
+  override fun generateEcdsa(comment: String): SshKeyPair {
+    val keyPair: KeyPair = KeyPair.genKeyPair(JSch(), KeyPair.ECDSA, 521)
 
     var publicKey: String
     ByteArrayOutputStream().use { stream ->

--- a/shared/src/commonMain/kotlin/me/saket/press/shared/preferences/sync/setup/GitHostIntegrationPresenter.kt
+++ b/shared/src/commonMain/kotlin/me/saket/press/shared/preferences/sync/setup/GitHostIntegrationPresenter.kt
@@ -191,7 +191,7 @@ class GitHostIntegrationPresenter(
         val token = authToken.get()!!
         val deployKey = GitHostService.DeployKey(
           title = "Press (${deviceInfo.deviceName()})",
-          key = sshKeygen.generateRsa(comment = "(Created by Press)")
+          key = sshKeygen.generateEcdsa(comment = "(Created by Press)")
         )
         gitHostService.addDeployKey(token, repo, deployKey)
           .andThen(completeSetup(repo, deployKey, userSetting.get()!!))


### PR DESCRIPTION
The sync with GitHub fails with the error: `git@github.com:[REPOSITORY].git: ERROR: You're using an RSA key with SHA-1, which is no longer allowed. Please use a newer client or a different key type.`

As of March 15, 2022 GitHub permanently stopped accepting old key types (Source: https://github.blog/2021-09-01-improving-git-protocol-security-github/).

I replaced the RSA key with ECDSA-521. If the specific error returned by GitHub is recognized (by error message) the repository is removed and the user needs to add it again manually so that the new key can be deployed.